### PR TITLE
Stop allowing Chromium to ask to be the default browser

### DIFF
--- a/kiosk/kiosk.sh
+++ b/kiosk/kiosk.sh
@@ -8,7 +8,7 @@ unclutter -idle 0.5 -root &
 sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' /home/pi/.config/chromium/Default/Preferences
 sed -i 's/"exit_type":"Crashed"/"exit_type":"Normal"/' /home/pi/.config/chromium/Default/Preferences
 
-/usr/bin/chromium-browser --noerrdialogs --disable-infobars --kiosk https://www.theguardian.com/uk &
+/usr/bin/chromium-browser --noerrdialogs --disable-infobars --no-default-browser-check --kiosk https://www.theguardian.com/uk &
 
 while true; do # as soon as this script exits, the browser window will be killed...
    sleep 10


### PR DESCRIPTION
When the script `kiosk.sh` opens a web page with Chromium it also describes how to make sure that the page appears it its full glory, unencumbered by dialog boxes, for example like this:
![image](https://user-images.githubusercontent.com/3072877/95577261-b9148a00-0a29-11eb-9e13-9689ecc46c71.png)

When it was reported that the Ophan dashboard was appearing like this:
![image](https://user-images.githubusercontent.com/3072877/95577208-9da97f00-0a29-11eb-8fb1-bf26283ed81b.png)

We restarted the raspberry pi but this dialog still appeared:
![image](https://user-images.githubusercontent.com/3072877/95577530-35a76880-0a2a-11eb-97be-ee1d01a98550.png)

This PR adds the flag --no-default-browser-check to ensure that the `Chromium isn't your default browser` dialog is suppressed. 


